### PR TITLE
git-cleanup: optionally take the target branch as an argument

### DIFF
--- a/git-cleanup/git-cleanup.go
+++ b/git-cleanup/git-cleanup.go
@@ -10,13 +10,17 @@ import (
 	"bufio"
 	"bytes"
 	"log"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 )
 
+// BUG: cherry-pick branches will be removed as soon as the main CL is merged,
+// as cherry-picks have the same Change-Id as the original CL.
+
 func main() {
-	curBranch := ""
+	var targetBranch string
 	out, err := exec.Command("git", "branch").Output()
 	if err != nil {
 		log.Fatalf("Error running git branch: %v", err)
@@ -24,28 +28,27 @@ func main() {
 	var branches []string
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
-		cur := false
 		if strings.HasPrefix(line, "* ") {
 			line = line[2:]
-			cur = true
+			targetBranch = line
 		}
 		if line == "" {
 			continue
 		}
 		branches = append(branches, line)
-		if cur {
-			curBranch = line
-		}
 	}
-	if !isMainBranch(curBranch) {
-		log.Fatalf("On branch %s; must be on master or a dev branch", curBranch)
+	if len(os.Args) > 1 {
+		targetBranch = os.Args[1]
+	}
+	if !isMainBranch(targetBranch) {
+		log.Fatalf("Selected branch %s; must be a master or a dev branch.", targetBranch)
 	}
 
 	for _, br := range branches {
 		if isMainBranch(br) {
 			continue
 		}
-		if isSubmitted(branchChangeID(br)) {
+		if isSubmitted(targetBranch, branchChangeID(br)) {
 			// Display a ref for the branch we're about to delete,
 			// so that if we screw up (never!), the user can get it back easily.
 			short, err := exec.Command("git", "rev-parse", "--short", "refs/heads/"+br).Output()
@@ -77,7 +80,7 @@ var changeRx = regexp.MustCompile(`(?m)^\s*Change-Id: (I[0-9a-f]+)`)
 
 // returns change-id or the empty string
 func branchChangeID(br string) string {
-	out, err := exec.Command("git", "show", br, "--").CombinedOutput()
+	out, err := exec.Command("git", "show", br).CombinedOutput()
 	if err != nil {
 		log.Printf("Error running git show %v: %v: %s", br, err, out)
 	}
@@ -89,14 +92,15 @@ func branchChangeID(br string) string {
 
 // isMainBranch reports whether br is a shared development branch.
 func isMainBranch(br string) bool {
+	br = strings.TrimPrefix(br, "origin/")
 	return br == "master" || strings.HasPrefix(br, "dev.")
 }
 
-func isSubmitted(changeID string) bool {
+func isSubmitted(br, changeID string) bool {
 	if changeID == "" {
 		return false
 	}
-	for _, v := range changeIDLog() {
+	for _, v := range changeIDLog(br) {
 		if v == changeID {
 			return true
 		}
@@ -104,35 +108,36 @@ func isSubmitted(changeID string) bool {
 	return false
 }
 
-var changeIDLogCache []string
+var changeIDLogCache = make(map[string][]string)
 
-func changeIDLog() (ret []string) {
-	if v := changeIDLogCache; v != nil {
+func changeIDLog(br string) (ret []string) {
+	if v, ok := changeIDLogCache[br]; ok {
 		return v
 	}
-	defer func() { changeIDLogCache = ret }()
-	cmd := exec.Command("git", "log", "-F", "--grep", "Change-Id:")
+	defer func() { changeIDLogCache[br] = ret }()
+	cmd := exec.Command("git", "log", "-F", "--grep", "Change-Id:", br)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Fatalf("pipe error: %v", err)
+		log.Fatalf("Pipe error: %v", err)
 	}
 	if err := cmd.Start(); err != nil {
-		log.Fatalf("error running git log: %v", err)
+		log.Fatalf("Error running git log: %v", err)
 	}
 	bs := bufio.NewScanner(stdout)
-	wantLine := []byte("Change-Id: ")
+	const wantLine = "Change-Id: "
 	for bs.Scan() {
-		if !bytes.Contains(bs.Bytes(), wantLine) {
+		line := strings.TrimSpace(bs.Text())
+		if !strings.HasPrefix(line, wantLine) {
 			continue
 		}
-		changeID := strings.TrimPrefix(strings.TrimSpace(bs.Text()), "Change-Id: ")
+		changeID := strings.TrimPrefix(line, wantLine)
 		ret = append(ret, changeID)
 	}
 	if err := bs.Err(); err != nil {
-		log.Fatalf("error running git log: %v", err)
+		log.Fatalf("Error running git log: %v", err)
 	}
 	if err := cmd.Wait(); err != nil {
-		log.Fatalf("error running git log: %v", err)
+		log.Fatalf("Error running git log: %v", err)
 	}
 	return
 }


### PR DESCRIPTION
This lets me do "git cleanup origin/dev.boringcrypto" without actually
having a dev.boringcrypto tracking branch.