### PR TITLE
README.md install instructions updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ For now only `git-cleanup`.
 Install with:
 
 ```
-  $ go get github.com/bradfitz/gitutil/git-cleanup
+  $ go install github.com/bradfitz/gitutil/git-cleanup@latest
 ```
 
 Use like:


### PR DESCRIPTION
cannot install tools with `go get`. update instructions to `go install` syntax

This message is from using `go get`
```go get github.com/bradfitz/gitutil/git-cleanup
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```