### PR TITLE
git-cleanup: pass -- to git show to distinguish branch name

### DIFF
--- a/git-cleanup/git-cleanup.go
+++ b/git-cleanup/git-cleanup.go
@@ -85,7 +85,7 @@ var changeRx = regexp.MustCompile(`(?m)^\s*Change-Id: (I[0-9a-f]+)`)
 
 // returns change-id or the empty string
 func branchChangeID(br string) string {
-	out, err := exec.Command("git", "show", br).CombinedOutput()
+	out, err := exec.Command("git", "show", br, "--").CombinedOutput()
 	if err != nil {
 		log.Printf("Error running git show %v: %v: %s", br, err, out)
 	}


### PR DESCRIPTION
Otherwise if you have, for example, a branch named "reflect", whose name is the same as a top-level directory,
git-cleanup fails with

2025/11/06 10:05:19 Error running git show reflect: exit status 128: fatal: ambiguous argument 'reflect': both revision and filename Use '--' to separate paths from revisions, like this: 'git <command> [<revision>...] -- [<file>...]'